### PR TITLE
[#81] hotfix: 한글 입력시 Enter 대응

### DIFF
--- a/client/src/components/BlockContent.tsx
+++ b/client/src/components/BlockContent.tsx
@@ -80,8 +80,10 @@ export default function BlockContent({
     } else {
       /* 하단에 새로운 블록 생성 */
       e.preventDefault();
-      /* TODO: 새로운 블록 생성하는 로직추가 */
-      newBlock({ blockId, type: decisionNewBlockType(type), content: '', index: index + 1 });
+      if (!e.nativeEvent.isComposing) {
+        /* 한글 입력시 isComposing이 false일때만 실행 */
+        newBlock({ blockId, type: decisionNewBlockType(type), content: '', index: index + 1 });
+      }
     }
   };
   const handleOnSpace = (e: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
isComposing가 아닐때만 키입력에 대한 함수 호출하여 해결

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- hotfix/81 -> dev

### 변경 사항
한글 상태에서 enter 입력시 isComposing이 false 시에만 동작토록 수정