### PR TITLE
bug: 엔터의 e.code가 서로 달라서 생기는 문제 해결

### DIFF
--- a/client/src/components/BlockContent.tsx
+++ b/client/src/components/BlockContent.tsx
@@ -151,7 +151,7 @@ export default function BlockContent({
   };
 
   const handleOnKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.code === 'Enter') {
+    if (e.key === 'Enter') {
       handleOnEnter(e);
     } else if (e.code === 'Space') {
       handleOnSpace(e);


### PR DESCRIPTION
중앙 엔터의 e.code는 Enter
넘버패드 엔터의 e.code는 NumpadEnter
두 엔터모두 e.key는 Enter로 동일하므로
엔터 입력 판별을 e.code에서 e.key로 교체

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- bug/127 -> dev