### PR TITLE
[#209] refactor: 블록에서 paste 기본동작 막고 기능 수정

### DIFF
--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -325,7 +325,7 @@ export default function BlockContent({
             createBlock({
               prevBlockId: page.nextId,
               index: index + 2,
-              type: 'Text',
+              type: 'TEXT',
               content: '',
             });
           };

--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -346,13 +346,12 @@ export default function BlockContent({
         );
       }
     } else if (clipboardData.getData('text') !== '') {
-      createBlock({
-        prevBlockId: blockId,
-        index: index + 1,
-        type: 'TEXT',
-        content: (e.target as HTMLElement).textContent || '' + clipboardData.getData('text'),
+      changeBlock({
+        block: {
+          ...block,
+          content: (e.target as HTMLElement).textContent || '' + clipboardData.getData('text'),
+        },
       });
-      // focus 여부 확인 필
     }
   };
 

--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -370,7 +370,7 @@ export default function BlockContent({
       {beforeContent !== '' && <BeforeContentBox beforeContent={beforeContent} />}
       <BlockContentBox
         // type => css
-        contentEditable
+        contentEditable={type === 'IMG' ? false : true}
         suppressContentEditableWarning={true}
         className="content"
         onKeyDown={handleOnKeyDown}

--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -345,6 +345,14 @@ export default function BlockContent({
           headers,
         );
       }
+    } else if (clipboardData.getData('text') !== '') {
+      createBlock({
+        prevBlockId: blockId,
+        index: index + 1,
+        type: 'TEXT',
+        content: (e.target as HTMLElement).textContent || '' + clipboardData.getData('text'),
+      });
+      // focus 여부 확인 필
     }
   };
 

--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -292,9 +292,10 @@ export default function BlockContent({
   };
 
   const handleOnPaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault();
     const clipboardData = e.clipboardData;
 
-    if (clipboardData && clipboardData.files.length > 0) {
+    if (clipboardData.files.length > 0) {
       const getOnSuccess = (blockId: string) => (response: AxiosResponse<any, any>) => {
         response?.data?.url &&
           changeBlock({ block: { blockId, type: 'IMG', content: response.data.url } });
@@ -308,8 +309,6 @@ export default function BlockContent({
       const headers = { 'Content-Type': 'application/octet-stream' };
       const file = clipboardData.files[0];
       if (/image/.test(file.type)) {
-        e.preventDefault();
-
         let newImgBlockId: string;
         if (type === 'TEXT' && content === '') {
           /* 비어있는 Text 블록 => 현재 블록 체인지 */


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- Feature/209 -> dev

### 변경 사항
- 블록에서 onpaste 시 기본동작을 막았습니다.
- 텍스트블록 생성시 'Text'로 잘못 쓰여있던 타입명을 'TEXT'로 수정
- 이미지 블록 생성 외에도, 일반 텍스트 복사시 해당 블록에 텍스트 붙여넣기