### PR TITLE
[#209] refactor: 블록에서 Text paste 기능 수정

### DIFF
--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -120,7 +120,7 @@ const splitTextContentByCaret = (elem: HTMLElement) => {
   const totalContent = elem.textContent || '';
   const offset = (window.getSelection() as Selection).focusOffset;
   return [totalContent.slice(0, offset), totalContent.slice(offset)];
-}
+};
 
 export default function BlockContent({
   block,
@@ -365,15 +365,16 @@ export default function BlockContent({
       }
     } else if (clipboardData.getData('text') !== '') {
       const elem = e.target as HTMLElement;
-      const [preText, postText] = splitTextContentByCaret(elem)
+      const [preText, postText] = splitTextContentByCaret(elem);
       const newTextContent = preText + clipboardData.getData('text') + postText;
       elem.normalize();
       changeBlock({
         block: { ...block, content: newTextContent },
-        callBack: () => handleSetCaretPositionById({
+        callBack: () =>
+          handleSetCaretPositionById({
             targetBlockId: blockId,
-            caretOffset: newTextContent.length - postText.length
-          })
+            caretOffset: newTextContent.length - postText.length,
+          }),
       });
     }
   };

--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -116,6 +116,12 @@ const checkMarkDownGrammer = (text: string) => {
   return matched === undefined ? '' : matched.getType(text);
 };
 
+const splitTextContentByCaret = (elem: HTMLElement) => {
+  const totalContent = elem.textContent || '';
+  const offset = (window.getSelection() as Selection).focusOffset;
+  return [totalContent.slice(0, offset), totalContent.slice(offset)];
+}
+
 export default function BlockContent({
   block,
   createBlock,
@@ -358,11 +364,16 @@ export default function BlockContent({
         );
       }
     } else if (clipboardData.getData('text') !== '') {
+      const elem = e.target as HTMLElement;
+      const [preText, postText] = splitTextContentByCaret(elem)
+      const newTextContent = preText + clipboardData.getData('text') + postText;
+      elem.normalize();
       changeBlock({
-        block: {
-          ...block,
-          content: (e.target as HTMLElement).textContent || '' + clipboardData.getData('text'),
-        },
+        block: { ...block, content: newTextContent },
+        callBack: () => handleSetCaretPositionById({
+            targetBlockId: blockId,
+            caretOffset: newTextContent.length - postText.length
+          })
       });
     }
   };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/209-2 -> dev

### 변경 사항
splitTextContentByCaret 함수 작성
- Caret 위치를 기준으로 preText & postText로 분리
- 텍스트 붙여넣기시, 해당 위치에 텍스트가 붙여지도록 설정 normalize() 적용
- 개행이 포함되어 있어서 텍스트 노드를 양산하는 경우를 normalize changeBlock 호출 & callBack으로 카렛포지션세팅
- 컨텐츠의 변화 & 카렛 지정을 함께하기 위해 changeBlock 활용
- newTextContent.length - postText.length로 caretOffset 세팅