### PR TITLE
[#236] hotfixes: 이미지 블록의 좌측 BlockButton이 보이지 않는 현상

### DIFF
--- a/client/src/components/block/StyledBlockContent.tsx
+++ b/client/src/components/block/StyledBlockContent.tsx
@@ -161,7 +161,7 @@ const H3BlockContentBox = styled.div`
 `;
 
 const IMGBlockContentBox = styled.div`
-  overflow: hidden;
+  object-fit: cover;
   cursor: pointer;
   width: 100%;
 `;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- Hotfixes/236 -> dev

### 변경 사항
- 이미지블록의 overflow:hidden에 의해 해당 BlockButton이 보이지 않는 현상 수정

resolve: #236