### PR TITLE
[#229] hotfixes: onDrop 이벤트 기본동작 방지

### DIFF
--- a/client/src/components/block/BlockContent.tsx
+++ b/client/src/components/block/BlockContent.tsx
@@ -122,6 +122,8 @@ const splitTextContentByCaret = (elem: HTMLElement) => {
   return [totalContent.slice(0, offset), totalContent.slice(offset)];
 };
 
+const preventDefaultEvent = (e: any) => e.preventDefault();
+
 export default function BlockContent({
   block,
   createBlock,
@@ -410,6 +412,7 @@ export default function BlockContent({
         onMouseDown={(e) => {
           e.stopPropagation();
         }}
+        onDrop={preventDefaultEvent}
       >
         {block.type === 'IMG' ? (
           <img


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- hotfixes/229 -> dev

### 변경 사항
- contentEditable 블록의 onDrop 기본 동작을 방지하여, 핸들링 되지 못한 붙여넣기 현상을 방지한다.

resolve: #229 